### PR TITLE
Add ubuntu support

### DIFF
--- a/chapters/chapter1-create-your-kubernetes-cluster/scripts/prepare-env.sh
+++ b/chapters/chapter1-create-your-kubernetes-cluster/scripts/prepare-env.sh
@@ -105,17 +105,8 @@ install_cli_tool() {
     fi
 }
 
+# Install Prerequisites for macOS
 install_on_macOS() {
-    # Install Homebrew
-    if ! command -v brew; then
-        echo "INFO: Installing Homebrew."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-        brew update
-        echo "INFO: Homebrew installed successfully."
-    else
-        echo "INFO: Homebrew is already installed."
-    fi
-
     # Install CLIs
     install_cli_tool "brew" '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"' # Install Homebrew if not installed
     install_cli_tool "terraform" "brew install hashicorp/tap/terraform" # Install Terraform
@@ -140,7 +131,7 @@ install_on_Ubuntu() {
     install_cli_tool "oci" 'curl -LO "https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh"; chmod +x install.sh; sudo ./install.sh --install-dir /opt/oracle/cli --exec-dir /usr/bin --accept-all-defaults; sudo rm install.sh'
 }
 
-#Check type of OS
+#Check OS type
 case $OS in
 
   "Ubuntu")


### PR DESCRIPTION
### What changes? - Added Ubuntu OS support for prepare-env.sh script in chapter1

- The script will now check if runing on Darwin or Ubuntu and will install all prerequisites accordingly
- The install_with_brew function changed to install_cli_tool and will now will recive as an argument the full command to run to install the tool

### Why? - The script was only support macOS

### Testing

The update script tested on:
Ubuntu 22.04
Ubuntu 20.04
macOS 13

**To test in in ubuntu you excute the following commands:**
```
$ cd chapters/chapter1-create-your-kubernetes-cluster/scripts
$ UBUNTU_VERSION=22.04
$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp ubuntu:$UBUNTU_VERSION ./prepare-env.sh y@y.com && python3.10 -V; kubectl version; terraform -version; oci -version
```